### PR TITLE
Put session structure information for 2025 and 2026 separated.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This material was first delivered at the 2025 ICCS summer school, see the [part 
 
 The slides are included in this repository in [slides.pdf](https://github.com/Cambridge-ICCS/testing-workshop/blob/main/slides.pdf) (and the Keynote source in [slides.key](https://github.com/Cambridge-ICCS/testing-workshop/blob/main/slides.key)).
 
-The structure of the session for the ICCS summer school version of this workshop is described in more detail in [session-structure.md](https://github.com/Cambridge-ICCS/testing-workshop/blob/session-structure/session-structure.md).
+The structure of the session for the ICCS summer school version of this workshop is described in more detail in [session-structure.md](session-structure.md).
 
 ### Examples and exercises
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ This material was first delivered at the 2025 ICCS summer school, see the [part 
 
 ### Slides
 
-The slides are included in this repository.
+The slides are included in this repository in [slides.pdf](https://github.com/Cambridge-ICCS/testing-workshop/blob/main/slides.pdf) (and the Keynote source in [slides.key](https://github.com/Cambridge-ICCS/testing-workshop/blob/main/slides.key)).
+
+The structure of the session for the ICCS summer school version of this workshop is described in more detail in [session-structure.md](https://github.com/Cambridge-ICCS/testing-workshop/blob/session-structure/session-structure.md).
 
 ### Examples and exercises
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This material was first delivered at the 2025 ICCS summer school, see the [part 
 
 ### Slides
 
-The slides are included in this repository in [slides.pdf](https://github.com/Cambridge-ICCS/testing-workshop/blob/main/slides.pdf) (and the Keynote source in [slides.key](https://github.com/Cambridge-ICCS/testing-workshop/blob/main/slides.key)).
+The slides are included in this repository in [slides.pdf](slides.pdf) (and the Keynote source in [slides.key](slides.key)).
 
 The structure of the session for the ICCS summer school version of this workshop is described in more detail in [session-structure.md](session-structure.md).
 

--- a/README.md
+++ b/README.md
@@ -45,25 +45,6 @@ The `example` folder provides a small 0-dimensional Energy Balance Model for a p
 
 Coming soon
 
-### Session structure of 2025 course
-
-Session 1 - 1h
-- 10 minute intro about correctness and testing
-- 50 minutes explaining concepts about unit testing including
-     * Parameterised tests
-     * Fixtures
-     * Negative tests
-     * Approximation and floating point
-     * TDD
-     * Code coverage
-
-Session 2 - 1h30
-- 20 minute unit test exercises
-- 40 minutes lecture
-    - Integration and end-to-end tests
-    - Property-based testing
-- 30 minutes exercises (property-based test exercises)
-
 ## Preparation and prerequisites
 
 ### Prerequisites

--- a/session-structure.md
+++ b/session-structure.md
@@ -1,0 +1,37 @@
+### Session structure of 2026 course
+
+Session 1 - 1h30
+- 10 minute intro about correctness and testing
+- 55 minutes explaining concepts about unit testing including
+     * Parameterised tests
+     * Fixtures
+     * Negative tests
+     * Approximation and floating point
+     * TDD
+     * Code coverage
+- 25 minute unit test exercises
+
+Session 2 - 1h30
+- 50 minutes lecture
+    - Integration and end-to-end tests
+    - Property-based testing
+- 40 minutes exercises (property-based test exercises)
+
+### Session structure of 2025 course
+
+Session 1 - 1h
+- 10 minute intro about correctness and testing
+- 50 minutes explaining concepts about unit testing including
+     * Parameterised tests
+     * Fixtures
+     * Negative tests
+     * Approximation and floating point
+     * TDD
+     * Code coverage
+
+Session 2 - 1h30
+- 20 minute unit test exercises
+- 40 minutes lecture
+    - Integration and end-to-end tests
+    - Property-based testing
+- 30 minutes exercises (property-based test exercises)


### PR DESCRIPTION
- Removed session structure details for the 2025 course from readme
- Put session structure in separate file
- 2026 structure
- links to slides.
